### PR TITLE
JSON parsing an already parsed object

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,6 +141,9 @@ validate = function (min, map, srcs) {
     }
   });
 
+  if (typeof map === 'string') {
+    map = JSON.parse(map);
+  }
   assert.ok(map.sources && map.sources.length, 'There were no sources in the file');
   assert.ok(mappingCount > 0, 'There were no mappings in the file');
 };

--- a/index.js
+++ b/index.js
@@ -141,7 +141,7 @@ validate = function (min, map, srcs) {
     }
   });
 
-  assert.ok(JSON.parse(map).sources && JSON.parse(map).sources.length, 'There were no sources in the file');
+  assert.ok(map.sources && map.sources.length, 'There were no sources in the file');
   assert.ok(mappingCount > 0, 'There were no mappings in the file');
 };
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "git://github.com/ben-ng/sourcemap-validator.git"
   },
   "dependencies": {
-    "source-map": "~0.1.x",
+    "source-map": "^0.5.x",
     "lodash.foreach": "~2.3.x",
     "lodash.template": "~2.3.x",
     "jsesc": "~0.3.x"

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -25,6 +25,31 @@ each(fixtures, function (fixture) {
       validate(result.code, result.map, {'?': raw});
     }, 'Valid ' + fixture + ' sourcemap should not throw');
   };
+
+  tests['Uglified ' + fixture + ' should throw when missing sources'] = function () {
+    var raw = fs.readFileSync(path.join(libDir, fixture)).toString()
+      , result = uglify.minify(raw, {
+          outSourceMap: fixture + '.min.map'
+        , fromString: true
+        });
+
+    assert.throws(function () {
+      validate(result.code, result.map);
+    }, 'Valid ' + fixture + ' sourcemap should throw');
+  };
+
+  tests['Uglified (Inline source)' + fixture + ' should not throw'] = function () {
+    var raw = fs.readFileSync(path.join(libDir, fixture)).toString()
+      , result = uglify.minify(path.join(libDir, fixture), {
+          outSourceMap: fixture + '.min.map'
+        , fromString: false
+        , sourceMapIncludeSources: true
+        });
+
+    assert.doesNotThrow(function () {
+      validate(result.code, JSON.parse(result.map));
+    }, 'Valid ' + fixture + ' sourcemap should not throw');
+  };
 });
 
 module.exports = tests;


### PR DESCRIPTION
Resolved the type conflict between assertion in index.js and the required input for SMConsumer.
The SMConsumer by default requires a JSON object as it's argument, the same object is later parsed in the modified assert.