### PR TITLE
moved assignment of mapRef for performance reasons

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ var validate
   , SMConsumer = require('source-map').SourceMapConsumer
   , each = require('lodash.foreach')
   , template = require('lodash.template')
-  , jsesc = require('jsesc');
+  , jsesc = require('jsesc')
+  , fancyArrow = String.fromCharCode(parseInt(2192,16));
 
 // Lifted from UglifyJS
 toAscii = function (str, identifier) {
@@ -85,16 +86,15 @@ validate = function (min, map, srcs) {
     // These validations can't be performed with just the mapping
     var originalLine
       , errMsg
-      , mapRef = template('<%=generatedLine%>:<%=generatedColumn%>'
-          + String.fromCharCode(parseInt(2192,16)) // Fancy arrow!
-          + '<%=originalLine%>:<%=originalColumn%> "<%=name%>" in <%=source%>')(mapping)
+      , mapRef
       , expected
       , actuals = []
       , success = false;
 
     if(mapping.name) {
-      if(!splitSrcs[mapping.source])
+      if(!splitSrcs[mapping.source]) {
         throw new Error(mapping.source + ' not found in ' + Object.keys(splitSrcs).join(', '));
+      }
 
       originalLine = splitSrcs[mapping.source][mapping.originalLine - 1];
 
@@ -125,6 +125,9 @@ validate = function (min, map, srcs) {
       };
 
       if(!success) {
+        mapRef = template('<%=generatedLine%>:<%=generatedColumn%>'
+                          + fancyArrow
+                          + '<%=originalLine%>:<%=originalColumn%> "<%=name%>" in <%=source%>')(mapping);
         errMsg = template(''
           + 'Warning: mismatched names\n'
           + 'Expected: <%=expected%>\n'


### PR DESCRIPTION
I was working in ember-cli, and found that when I would work in Chrome Dev Tools, doing a 'validate' on a new ember generated project would take 250 seconds (and process 55K mappings), while doing the same project while not in Dev Tools would take only 800 ms for the same set of mappings. 

I'm not sure why, but I tracked the time down to the call to create the mapRef variable, which happens once per mapping. The time is spent in lodash.template(). Since the variable is only used once, in constructing an error message if there is a problem, I moved the statement that sets mapRef into that block. Now running in Dev Tools takes about the same time as without the debugger. I also moved the creation of a 'fancyArrow' character to a constant when the function starts.