### PR TITLE
Support charset in inlined sourcemap

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ validate = function (min, map, srcs) {
   // If no map was given, try to extract it from min
   if(map == null) {
     try {
-      var re = /\s*\/\/(?:@|#) sourceMappingURL=data:application\/json;(?:charset=utf-8;)?base64,(\S*)$/m
+      var re = /\s*\/\/(?:@|#) sourceMappingURL=data:application\/json;(?:charset=utf-?8;)?base64,(\S*)$/m
         , map = min.match(re);
 
       map = createBuffer(map[1], 'base64').toString();

--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ validate = function (min, map, srcs) {
   // If no map was given, try to extract it from min
   if(map == null) {
     try {
-      var re = /\s*\/\/(?:@|#) sourceMappingURL=data:application\/json;base64,(\S*)$/m
+      var re = /\s*\/\/(?:@|#) sourceMappingURL=data:application\/json;(?:charset=utf-8;)?base64,(\S*)$/m
         , map = min.match(re);
 
       map = createBuffer(map[1], 'base64').toString();

--- a/tests/unit.js
+++ b/tests/unit.js
@@ -92,6 +92,16 @@ tests['Valid Minifyified bundle with inline sourcemap should not throw'] = funct
   }, 'Valid Minifyified inline sourcemap and inline sourceContent should not throw');
 };
 
+tests['Valid Minifyified bundle with inline sourcemap and charset should not throw'] = function () {
+  var mfDir = path.join(validDir, 'Minifyified')
+    , min = fs.readFileSync(path.join(mfDir, 'bundle.min.js')).toString()
+      .replace('/json;base64,', '/json;charset=utf-8;base64,');
+
+  assert.doesNotThrow(function () {
+    validate(min);
+  }, 'Valid Minifyified inline sourcemap and inline sourceContent should not throw');
+};
+
 tests['Valid Babel map should not throw'] = function () {
   var babelDir = path.join(validDir, 'Babel')
     , map = fs.readFileSync(path.join(babelDir, 'router.js.map')).toString();

--- a/tests/unit.js
+++ b/tests/unit.js
@@ -102,6 +102,16 @@ tests['Valid Minifyified bundle with inline sourcemap and charset should not thr
   }, 'Valid Minifyified inline sourcemap and inline sourceContent should not throw');
 };
 
+tests['Valid Minifyified bundle with charset without hyphen should not throw'] = function () {
+  var mfDir = path.join(validDir, 'Minifyified')
+    , min = fs.readFileSync(path.join(mfDir, 'bundle.min.js')).toString()
+      .replace('/json;base64,', '/json;charset=utf8;base64,');
+
+  assert.doesNotThrow(function () {
+    validate(min);
+  }, 'Valid Minifyified inline sourcemap and inline sourceContent should not throw');
+};
+
 tests['Valid Babel map should not throw'] = function () {
   var babelDir = path.join(validDir, 'Babel')
     , map = fs.readFileSync(path.join(babelDir, 'router.js.map')).toString();


### PR DESCRIPTION
This PR adds suport for the `charset=utf8;` sequence in inlined sourcemap like the one generated by [magic-string](https://www.npmjs.com/package/magic-string).

I do not know if this is standard, but magic-string has more than 1 million weekly downloads, so I think it is better to support it.

Thanks for this excellent tool.