### PR TITLE
Replace unmaintained lodash per-method packages with full lodash

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,8 @@ var validate
   , toAscii
   , assert = require('assert')
   , SMConsumer = require('source-map').SourceMapConsumer
-  , each = require('lodash.foreach')
-  , template = require('lodash.template')
+  , each = require('lodash/foreach')
+  , template = require('lodash/template')
   , jsesc = require('jsesc')
   , fancyArrow = String.fromCharCode(parseInt(2192,16));
 

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
   },
   "dependencies": {
     "jsesc": "~0.3.x",
-    "lodash.foreach": "^4.5.0",
-    "lodash.template": "^4.5.0",
+    "lodash": "^4.17.21",
     "source-map": "~0.1.x"
   },
   "files": [

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -3,7 +3,7 @@ var validate = require('..')
   , path = require('path')
   , assert = require('assert')
   , uglify = require('uglify-js')
-  , each = require('lodash.foreach')
+  , each = require('lodash/foreach')
   , libDir = path.join(__dirname, 'fixtures', 'integration')
   , tests = {}
   , fixtures;

--- a/yarn.lock
+++ b/yarn.lock
@@ -35,30 +35,10 @@ jsesc@~0.3.x:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.3.0.tgz#1bf5ee63b4539fe2e26d0c1e99c240b97a457972"
   integrity sha1-G/XuY7RTn+LibQwemcJAuXpFeXI=
 
-lodash._reinterpolate@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
-  integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
-
-lodash.foreach@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
-  integrity sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=
-
-lodash.template@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.5.0.tgz#f976195cf3f347d0d5f52483569fe8031ccce8ab"
-  integrity sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==
-  dependencies:
-    lodash._reinterpolate "^3.0.0"
-    lodash.templatesettings "^4.0.0"
-
-lodash.templatesettings@^4.0.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz#e481310f049d3cf6d47e912ad09313b154f0fb33"
-  integrity sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==
-  dependencies:
-    lodash._reinterpolate "^3.0.0"
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 lru-cache@2:
   version "2.7.3"


### PR DESCRIPTION
[CVE-2021-23337](https://github.com/advisories/GHSA-35jh-r3h4-6jhm) was recently updated to reflect an issue previously patched in Lodash also being present in the `lodash.template` package, which from all appearances is [no longer maintained](https://github.com/lodash/lodash/issues/5738#issuecomment-1737782579), resulting in users receiving NPM/GitHub alerts related to this advisory. For that matter, `lodash.foreach` appears to be similarly unmaintained.

I should emphasize there's nothing I've seen to suggest that `sourcemap-validator`'s usage is risky but in my mind it is still something worth fixing.

Under the circumstances I've replaced these two sub-packages with the current full version of lodash, and adjusted `require` calls where needed.

I would also request to back-merge this update to the v1 release line if possible.