### PR TITLE
fix(deps): source-map@~0.1.x->~0.5.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "jsesc": "~0.3.x",
     "lodash.foreach": "^4.5.0",
     "lodash.template": "^4.5.0",
-    "source-map": "~0.1.x"
+    "source-map": "~0.5.7"
   },
   "files": [
     "index.js"

--- a/yarn.lock
+++ b/yarn.lock
@@ -85,12 +85,10 @@ source-map@0.1.34:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@~0.1.x:
-  version "0.1.43"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.43.tgz#c24bc146ca517c1471f5dacbe2571b2b7f9e3346"
-  integrity sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=
-  dependencies:
-    amdefine ">=0.0.4"
+source-map@~0.5.7:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+  integrity sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==
 
 uglify-js@2.4.x:
   version "2.4.24"


### PR DESCRIPTION
Includes many fixes and improvements.

[Changelog](https://github.com/mozilla/source-map/blob/master/CHANGELOG.md)

While a bump to newer `0.7` seems preferred, it is a breaking change (due to API changing to async), so I'm thinking that this PR might be considered for a minor release, and bumping further to 0.7 can then be done in a follow-up.